### PR TITLE
Update prop1 and eVar35 values:

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -237,7 +237,7 @@ class TestOmnitureTag(unittest.TestCase):
 
     def test_build_prop1(self):
         omni_tag = base.OmnitureTag(OMNI_HOME_TAG)
-        self.assertEquals(omni_tag.build_prop1(), 'D=gn')
+        self.assertEquals(omni_tag.build_prop1(), 'D=pageName')
 
     def test_build_prop2(self):
         omni_tag = base.OmnitureTag(OMNI_HOME_TAG)
@@ -296,7 +296,7 @@ class TestOmnitureTag(unittest.TestCase):
 
     def test_build_eVar35(self):
         omni_tag = base.OmnitureTag(OMNI_HOME_TAG)
-        self.assertEquals(omni_tag.build_eVar35(), 'D=gn')
+        self.assertEquals(omni_tag.build_eVar35(), 'D=pageName')
 
     def test_home_tag(self):
         omni_tag = base.OmnitureTag(OMNI_HOME_TAG)

--- a/tribune_omniture/base.py
+++ b/tribune_omniture/base.py
@@ -201,7 +201,7 @@ class OmnitureTag(object):
         return self._build_hier()
 
     def build_prop1(self):
-        return "D=gn"
+        return "D=pageName"
 
     def build_prop2(self):
         try:
@@ -225,7 +225,7 @@ class OmnitureTag(object):
         return "D=ch"
 
     def build_eVar35(self):
-        return "D=gn"
+        return "D=pageName"
 
     def render(self):
         return generate_data_object_script(**self.build_vars())

--- a/tribune_omniture/django/tests.py
+++ b/tribune_omniture/django/tests.py
@@ -20,14 +20,14 @@ class TestTemplateTags(unittest.TestCase):
             'server': 'elections.chicagotribune.com',
             'hier1': 'chicagotribune:news:local:election',
             'hier2': 'news:local:election',
-            'prop1': 'D=gn',
+            'prop1': 'D=pageName',
             'prop2': 'news',
             'prop38': 'dataproject',
             'prop57': 'D=c38',
             'eVar20': 'chicagotribune',
             'eVar21': 'D=c38',
             'eVar34': 'D=ch',
-            'eVar35': 'D=gn',
+            'eVar35': 'D=pageName',
         }
         expected_param_strs = ["{}: '{}'".format(k, v) for k, v in
             expected_params.items()]


### PR DESCRIPTION
Our initial setup of the Omniture tag was based on outdated information. Update
the prop1 and eVar35 values based on the Tribune Data team's recommendation.
Update tests to reflect the new expected values.
