### PR TITLE
Create Jinja2 extension and tests:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,58 @@ Python package for rendering HTML snippets to enable Tribune Publishing's Omnitu
 Installation
 ------------
 
-    pip install git+https://github.com/newsapps/python-tribune-omniture.git#egg=tribune_omniture 
+    pip install git+https://github.com/newsapps/python-tribune-omniture.git#egg=tribune_omniture
 
+Implementation with Django applications
+---------------------------------------
 
+In your settings file, create an Omniture dictionary, which we will use to populate our JavaScript object. Here is an example:
+
+    OMNITURE = {
+      'domain': 'elections.chicagotribune.com',
+      'sitename': 'Chicago Tribune',
+      'section': 'news',
+      'subsection': 'local',
+      'subsubsection': 'election',
+      'title': 'Elections Center',
+      'type': 'dataproject',
+    }
+
+At the top of your project templates, load the custom template tags with:
+
+    {% load omnituretags %}
+
+In the head of your project templates, load the Omniture object. Replace PAGE NAME HERE with a name that properly identifies the page the user is viewing:
+
+    {% block omniture %}
+        {% omnitag request '' 'PAGE NAME HERE' %}
+    {% endblock %}
+
+In the footer of your project templates, load the Omniture third party script, and pass your domain (do not include a subdomain). By default, the third party navigation and SSOR tracking are disabled. The metrics team recommends disabling the SSOR tracking if page speed is a concern:
+
+    {% omniscript 'chicagotribune.com' %}
+
+Implementation with Tarbell (Jinja2) projects
+---------------------------------------------
+
+In your Tarbell config, update the DEFAULT_CONTEXT dictionary so it includes a nested Omniture dictionary, like this:
+
+    DEFAULT_CONTEXT = {
+        OMNITURE = {
+            'domain': 'nfldraft.chicagotribune.com',
+            'sitename': 'Chicago Tribune',
+            'section': 'sports',
+            'subsection': 'bears',
+            'subsubsection': '',
+            'title': 'NFL Draft',
+            'type': 'dataproject',
+        }
+    }
+
+In the head of your project templates, load the Omniture object. Replace PAGE NAME HERE with a name that properly identifies the page the user is viewing:
+
+    {% omnitag request config None 'PAGE NAME HERE' %}
+
+In the footer of your project templates, load the Omniture third party script, and pass your domain (do not include a subdomain). By default, the third party navigation and SSOR tracking are disabled. The metrics team recommends disabling the SSOR tracking if page speed is a concern:
+
+    {% omniscript 'chicagotribune.com' %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,8 @@
-nose==1.3.4
 Django==1.7.6
+Flask==0.10.1
+Jinja2==2.7.3
+MarkupSafe==0.23
+Werkzeug==0.10.4
+itsdangerous==0.24
+nose==1.3.4
+wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
     tests_require=[
         'nose',
         'Django',
+        'Flask',
+        'Jinja2',
     ],
     test_suite='nose.collector',
 )

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,0 +1,113 @@
+import unittest
+
+from flask import Flask, Request
+from jinja2 import Environment, Template
+from werkzeug.test import EnvironBuilder
+
+from tribune_omniture.jinja import OmnitureExtension
+
+OMNITURE = {
+    'domain': 'nfldraft.chicagotribune.com',
+    'sitename': 'Chicago Tribune',
+    'section': 'sports',
+    'subsection': 'bears',
+    'subsubsection': '',
+    'title': 'NFL Draft',
+    'type': 'dataproject',
+}
+
+class TestExtension(unittest.TestCase):
+    app = Flask('test')
+
+    def setUp(self):
+        # With Flask, variables passed to the template are available
+        # via app.config.
+        self.config = self.app.config
+        self.config.update(OMNITURE=OMNITURE)
+
+    def test_omnitag(self):
+        builder = EnvironBuilder(path='/', method='GET')
+        req = Request(builder.get_environ())
+        # Here we instantiate a Jinja environment, and pass it our
+        # OmnitureExtension class.
+        environment = Environment(extensions=[OmnitureExtension])
+        # We load our template from a simple string.
+        t = environment.from_string("{% omnitag request, config, None, \
+                                    'NFL Draft', 'dataproject' %}")
+
+        # Here is the context we will pass when we render our template.
+        c = {
+            'request': req,
+            'config': self.config,
+        }
+
+        expected_params = {
+            'pageName': 'ct:nfldraft:sports:bears:NFL-Draft:dataproject.',
+            'channel': 'sports:bears',
+            'server': 'nfldraft.chicagotribune.com',
+            'hier1': 'chicagotribune:sports:bears',
+            'hier2': 'sports:bears',
+            'prop1': 'D=pageName',
+            'prop2': 'sports',
+            'prop38': 'dataproject',
+            'prop57': 'D=c38',
+            'eVar20': 'chicagotribune',
+            'eVar21': 'D=c38',
+            'eVar34': 'D=ch',
+            'eVar35': 'D=pageName',
+        }
+        expected_param_strs = ["{}: '{}'".format(k, v) for k, v in
+            expected_params.items()]
+        rendered = t.render(**c)
+        expected_prefix = """<script>
+((((window.trb || (window.trb = {})).data || (trb.data = {})).metrics || (trb.data.metrics = {})).thirdparty = {"""
+        self.assertEqual(rendered.startswith(expected_prefix), True)
+        expected_suffix = """});
+</script>"""
+        self.assertEqual(rendered.endswith(expected_suffix), True)
+        for expected_param in expected_param_strs:
+            try:
+                param_index = rendered.index(expected_param)
+                self.assertTrue(param_index >
+                                rendered.index(expected_prefix) + 1)
+                self.assertTrue(param_index <
+                                rendered.index(expected_suffix))
+            except ValueError:
+                msg = "Parameter \"{}\" not found in expected position".format(
+                   expected_param)
+                raise ValueError(msg)
+
+    def test_omniscript(self):
+        expected_urls = [
+            "//chicagotribune.com/thirdpartyservice?disablenav=true&disablessor=true",
+            "//chicagotribune.com/thirdpartyservice",
+            "//chicagotribune.com/thirdpartyservice?disablenav=true",
+        ]
+
+        inputs = [
+            ["chicagotribune.com"],
+            ["chicagotribune.com", False, False],
+            ["chicagotribune.com", True, False],
+        ]
+
+        for args, expected_url in zip(inputs, expected_urls):
+            domain = args[0]
+            environment = Environment(extensions=[OmnitureExtension])
+            t = environment.from_string("{% omniscript domain, \
+                                        disable_nav, disable_ssor %}")
+            # Here is the context we will pass when we render our template,
+            # note that the disable values might be modified based on args.
+            ctx = {
+                'domain': domain,
+                'disable_nav': True,
+                'disable_ssor': True,
+            }
+            if len(args) > 1:
+                ctx['disable_nav'] = args[1]
+
+            if len(args) > 2:
+                ctx['disable_ssor'] = args[2]
+
+            rendered = t.render(ctx)
+            expected = "<script src='{}' async></script>".format(expected_url)
+            self.assertEqual(rendered, expected)

--- a/tribune_omniture/jinja/__init__.py
+++ b/tribune_omniture/jinja/__init__.py
@@ -1,0 +1,1 @@
+from .extension import OmnitureExtension

--- a/tribune_omniture/jinja/extension.py
+++ b/tribune_omniture/jinja/extension.py
@@ -1,0 +1,81 @@
+from jinja2 import nodes, Environment
+from jinja2.ext import Extension
+
+from tribune_omniture.base import (OmnitureTag,
+    generate_thirdpartyservice_script)
+
+class OmnitureExtension(Extension):
+    tags = set(['omnitag', 'omniscript'])
+
+    def parse(self, parser):
+        """
+        Parse the template for instances of our custom tags. And then parse
+        the arguments that were passed to the tag so we can call the methods
+        that output our Omniture snippets.
+
+        """
+        # The first token is the token that started the tag. In our case
+        # we only listen to ``'omnitag'`` or ``'omniscript'`` so this will be a
+        # name token with either `omnitag` or `omniscript` as the value. We get
+        # the line number so we can give it to the nodes we create by hand.
+        first_token = parser.stream.next()
+
+        lineno = first_token.lineno
+
+        # Check the value of first_token and set the name of the method we want
+        # to run. Else raise an error.
+        if str(first_token) == 'omnitag':
+            method_name = 'omnitag_render'
+        elif str(first_token) == 'omniscript':
+            method_name = 'omniscript_render'
+        else:
+            raise ValueError("Unexpected tag name '{}'".format(first_token))
+
+        # Now we parse the expressions passed to our custom tag.
+        args = [n for n in parser.parse_tuple().items]
+
+        # Now output the string that is returned by the method we call.
+        return nodes.Output([
+                            self.call_method(method_name, args)
+                            ]).set_lineno(lineno)
+
+    def omnitag_render(self, request, config,
+                        story, story_title='', page_type=None):
+        """
+        Render the Omniture tag snippet based on the arguments provided in
+        the custom tag of the template.
+
+        """
+        # Create a default dictionary based on the values provided by the
+        # Jinja config dictionary.
+        defaults = { key:value for key, value in config['OMNITURE'].items() }
+
+        defaults.setdefault('type', 'individualarticle')
+
+        if story:
+            story_title = story.get('title', '')
+
+        tag_attrs =  {
+            'title': story_title,
+        }
+
+        if page_type is not None:
+            tag_attrs['page_type'] = page_type
+
+        tag = OmnitureTag(dict(defaults.items(), **tag_attrs))
+        return tag.render()
+
+    def omniscript_render(self, domain, disable_nav=True, disable_ssor=True):
+        """
+        Template tag to generate the <script> tag to include the 3rd party 
+        header JavaScript.
+
+        """
+        if disable_nav == '':
+            disable_nav = True
+
+        if disable_ssor == '':
+            disable_ssor = True
+
+        return generate_thirdpartyservice_script(domain,
+                                                disable_nav, disable_ssor)


### PR DESCRIPTION
Update the README with more information on how to implement the Omniture
package with Django and Tarbell applications.

Update the requirements to include Flask and Jinja and their
dependencies.

Create a Jinja2 extension, which functions much like a Django custom template
tag. This will allow users to drop in a custom tag in their Tarbell templates,
which will render an Omniture JS object or script based on the context variables
a user defines in the custom tag or in the tarbell_config.

Related to Unfuddle #295 in the Admin project.
